### PR TITLE
Refactor Vale workflow into reusable workflow

### DIFF
--- a/.github/workflows/vale-reusable.yml
+++ b/.github/workflows/vale-reusable.yml
@@ -1,25 +1,28 @@
+---
 name: Vale Linting Reusable
-on: [workflow_call]
+
+on:
+  workflow_call:
 
 jobs:
   vale:
     name: runner / vale
     runs-on: ubuntu-latest
     steps:
-      # For AsciiDoc users:
-        - name: Install Asciidoctor
-          run: sudo apt-get install -y asciidoctor
-        - uses: actions/checkout@v4
-        - uses: errata-ai/vale-action@v2.1.1
-          with:
-            filter_mode: diff_context
-            vale_flags: "--no-exit --minAlertLevel=error --glob=*.adoc"
-            reporter: github-check
-            fail_on_error: true
-          env:
-            GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-            REVIEWDOG_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Install Asciidoctor
+        run: sudo apt-get install -y asciidoctor
 
+      - uses: actions/checkout@v4
+
+      - uses: errata-ai/vale-action@v2.1.1
+        with:
+          filter_mode: diff_context
+          vale_flags: "--no-exit --minAlertLevel=error --glob=*.adoc"
+          reporter: github-check
+          fail_on_error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 # For reStructuredText users:
 #      - name: Install docutils
 #        run: sudo apt-get install -y docutils

--- a/.github/workflows/vale-using-reusable.yml
+++ b/.github/workflows/vale-using-reusable.yml
@@ -1,10 +1,12 @@
+---
 name: Linting with Vale using Reusable Config
-on: 
-   push:
-      branches: [main]
-   pull_request:
-      branches: [main]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-   call-reusable-vale-workflow-in-riscv-vale-repo:
-      uses: riscv-admin/riscv-vale/.github/workflows/vale-reusable.yml@main
+  call-reusable-vale:
+    uses: ./.github/workflows/vale-reusable.yml


### PR DESCRIPTION
Refactor Vale linting workflow into a reusable workflow using `workflow_call`.

This extracts the Vale logic into `.github/workflows/vale-reusable.yml` and updates the caller workflow to reference it locally. This removes duplication and simplifies maintenance.

No behavior changes intended.
